### PR TITLE
fixups against go-imap v1

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,7 +22,7 @@ func (c *Client) SupportMove() (bool, error) {
 }
 
 func (c *Client) move(uid bool, seqset *imap.SeqSet, dest string) error {
-	if c.c.State != imap.SelectedState {
+	if c.c.State() != imap.SelectedState {
 		return client.ErrNoMailboxSelected
 	}
 

--- a/command.go
+++ b/command.go
@@ -15,7 +15,7 @@ type Command struct {
 }
 
 func (cmd *Command) Command() *imap.Command {
-	mailbox, _ := utf7.Encoder.String(cmd.Mailbox)
+	mailbox, _ := utf7.Encoding.NewEncoder().String(cmd.Mailbox)
 
 	return &imap.Command{
 		Name:      commandName,
@@ -40,7 +40,7 @@ func (cmd *Command) Parse(fields []interface{}) (err error) {
 	if !ok {
 		return errors.New("Mailbox name must be a string")
 	}
-	if cmd.Mailbox, err = utf7.Decoder.String(mailbox); err != nil {
+	if cmd.Mailbox, err = utf7.Encoding.NewDecoder().String(mailbox); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
There's no v1 branch on this repository.  Perhaps one should be created?  The following fixups are required to compile against go-imap v1.