### PR TITLE
Add MoveWithFallback and UidMoveWithFallback

### DIFF
--- a/client.go
+++ b/client.go
@@ -88,7 +88,7 @@ func (c *Client) UidMove(seqset *imap.SeqSet, dest string) error {
 }
 
 // MoveWithFallback tries to move if the server supports it. If it doesn't, it
-// falls back to copy, store and expunge, as defined in section 3.3 of RFC6851.
+// falls back to copy, store and expunge, as defined in RFC 6851 section 3.3.
 func (c *Client) MoveWithFallback(seqset *imap.SeqSet, dest string) error {
 	return c.moveWithFallback(false, seqset, dest)
 }


### PR DESCRIPTION
This PR adds a fallback if the [MOVE extension](https://tools.ietf.org/html/rfc6851) isn't supported by the server, as requested in #1.

The fallback consists of three commands: `COPY`, `STORE` and `EXPUNGE`, as described in [section 3.3 of RFC6851](https://tools.ietf.org/html/rfc6851#section-3.3).

I'm aware that the check for the `State` in ll. 25-27 and 51-53 is the same, but I thought having the logic of `move` and `moveWithFallback` separated outweights having the check twice. However I'm open to change this. :)

As to the rest I hope this PR meets the requirements to get merged.
Thanks.

Fixes #1